### PR TITLE
add diagonal movement

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,3 @@ DEPENDENCIES
   pry
   require_all
   rspec
-
-BUNDLED WITH
-   1.11.2

--- a/lib/rogue/models/coordinate.rb
+++ b/lib/rogue/models/coordinate.rb
@@ -35,4 +35,20 @@ class Coordinate
   def right
     Coordinate.new(x+1, y)
   end
+
+  def topleft
+    Coordinate.new(x-1, y-1)
+  end
+
+  def topright
+    Coordinate.new(x+1, y-1)
+  end
+
+  def bottomleft
+    Coordinate.new(x-1, y+1)
+  end
+
+  def bottomright
+    Coordinate.new(x+1, y+1)
+  end
 end

--- a/lib/rogue/models/npc_phase.rb
+++ b/lib/rogue/models/npc_phase.rb
@@ -5,8 +5,14 @@ class NpcPhase < Phase
       if npc.coord.adjacent?(@game.player.coord)
         npc.attack(@player)
       else
-        npc.move(direction: [:left, :right, :up, :down].sample)
+        npc.move(direction: random_direction )
       end
     end
+  end
+
+  private
+  def random_direction
+    [:left, :right, :up, :down, :topleft, 
+     :topright, :bottomleft, :bottomright].sample
   end
 end

--- a/lib/rogue/models/player_phase.rb
+++ b/lib/rogue/models/player_phase.rb
@@ -16,10 +16,14 @@ class Phase
 
   def directions
     {
-        'h' => :left,
-        'j' => :down,
-        'k' => :up,
-        'l' => :right
+      'h' => :left,
+      'j' => :down,
+      'k' => :up,
+      'l' => :right,
+      'u' => :topleft,
+      'i' => :topright,
+      'n' => :bottomleft,
+      'm' => :bottomright
     }
   end
 

--- a/spec/lib/game_spec.rb
+++ b/spec/lib/game_spec.rb
@@ -41,6 +41,26 @@ describe Rogue::Game do
         expect(player).to receive(:move).with({direction: :up})
         game.step('k')
       end
+
+      it 'moves the player diagonally to the topleft' do
+        expect(player).to receive(:move).with({direction: :topleft})
+        game.step('u')
+      end
+
+      it 'moves the player diagonally to the topright' do
+        expect(player).to receive(:move).with({direction: :topright})
+        game.step('i')
+      end
+
+      it 'moves the player diagonally to the bottomleft' do
+        expect(player).to receive(:move).with({direction: :bottomleft})
+        game.step('n')
+      end
+
+      it 'moves the player diagonally to the bottomright' do
+        expect(player).to receive(:move).with({direction: :bottomright})
+        game.step('m')
+      end
     end
 
     context 'attacking' do

--- a/spec/models/coordinate_spec.rb
+++ b/spec/models/coordinate_spec.rb
@@ -49,6 +49,26 @@ describe Coordinate do
       expect(coord.right).to eql Coordinate.new(7, 9)
     end
   end
+  describe '#topleft' do
+    it 'returns a coordinate above the current coordinate' do
+      expect(coord.topleft).to eql Coordinate.new(5, 8)
+    end
+  end
+  describe '#topright' do
+    it 'returns a coordinate above the current coordinate' do
+      expect(coord.topright).to eql Coordinate.new(7, 8)
+    end
+  end
+  describe '#bottomleft' do
+    it 'returns a coordinate above the current coordinate' do
+      expect(coord.bottomleft).to eql Coordinate.new(5, 10)
+    end
+  end
+  describe '#bottomright' do
+    it 'returns a coordinate above the current coordinate' do
+      expect(coord.bottomright).to eql Coordinate.new(7, 10)
+    end
+  end
   describe '#adjacent?' do
     it 'returns true when coordinates are next to each other' do
       expect(Coordinate.new(1, 3)).to be_adjacent(Coordinate.new(1,4))


### PR DESCRIPTION
This PR adds diagonal movement for the player using the following keys (as described in #11):

u = move top left
i = move top right
n = move bottom left
m = move bottom right

That's just based on games like nethack but it'd be cool to add some sort of button configuration at some point. 