### PR TITLE
add LOV restriction to AI movement

### DIFF
--- a/lib/rogue/models/npc_phase.rb
+++ b/lib/rogue/models/npc_phase.rb
@@ -6,7 +6,10 @@ class NpcPhase < Phase
         @game.add_message("#{npc.class} attacked Player")
         npc.attack(@player)
       else
-        npc.move(direction: AI.follow_direction(npc.coord, @player.coord))
+        helper = Rogue::VisionHelper.new
+        if helper.clear_path_between?(source: npc, target: @player)
+          npc.move(direction: AI.follow_direction(npc.coord, @player.coord))
+        end
       end
     end
   end

--- a/lib/rogue/models/npc_phase.rb
+++ b/lib/rogue/models/npc_phase.rb
@@ -6,8 +6,8 @@ class NpcPhase < Phase
         @game.add_message("#{npc.class} attacked Player")
         npc.attack(@player)
       else
-        helper = Rogue::VisionHelper.new
-        if helper.clear_path_between?(source: npc, target: @player)
+        helper = Rogue::VisionHelper
+        if helper.clear_path_between?(map: @map, source: npc, target: @player)
           npc.move(direction: AI.follow_direction(npc.coord, @player.coord))
         end
       end

--- a/lib/rogue/ui_helper.rb
+++ b/lib/rogue/ui_helper.rb
@@ -7,7 +7,6 @@ module Rogue
       @map = map
       @player = player
       @messages = messages
-      @vision_helper = VisionHelper.new(@map)
     end
 
     def draw
@@ -28,7 +27,7 @@ module Rogue
       (area[:y_lower_boundary]..area[:y_upper_boundary]).step  do |y|
         (area[:x_lower_boundary]..area[:x_upper_boundary]).step do |x|
           cell = @map.cell(Coordinate.new(x, y)) || NullCell.new
-          if cell.wall? || @vision_helper.clear_path_between?(source: @player, target: cell) 
+          if cell.wall? || VisionHelper.clear_path_between?(map: @map, source: @player, target: cell) 
             string << cell.to_s
           else
             string << "   "

--- a/lib/rogue/vision_helper.rb
+++ b/lib/rogue/vision_helper.rb
@@ -1,11 +1,8 @@
 module Rogue
   class VisionHelper
-    def initialize(map=Rogue.map)
-      @map = map
-    end
 
     # Check to see if the source can see the target
-    def clear_path_between?(source:, target:)
+    def self.clear_path_between?(map:, source:, target:)
       # walk along a line between the source and target
       x1, y1 = source.coord.x.to_f, source.coord.y.to_f
       x2, y2 = target.coord.x.to_f, target.coord.y.to_f
@@ -30,7 +27,7 @@ module Rogue
         y1 = y_move + y1
 
         # Find the cell at the new coordinate and determine if its a wall or not
-        cell = @map.cell(Coordinate.new(x1.round, y1.round))
+        cell = map.cell(Coordinate.new(x1.round, y1.round))
         return false if cell.wall?
 
         # Set the new delta values based on the current coordinate

--- a/lib/rogue/vision_helper.rb
+++ b/lib/rogue/vision_helper.rb
@@ -1,6 +1,6 @@
 module Rogue
   class VisionHelper
-    def initialize(map)
+    def initialize(map=Rogue.map)
       @map = map
     end
 

--- a/spec/lib/vision_helper_spec.rb
+++ b/spec/lib/vision_helper_spec.rb
@@ -1,8 +1,4 @@
 describe Rogue::VisionHelper do
-  it 'initializes with a map' do
-    Rogue::VisionHelper.new(map: double(:map))
-  end
-
   describe "#clear_path_between?" do
     before do
       @map = Map.new(height: 5, width: 5)
@@ -12,15 +8,15 @@ describe Rogue::VisionHelper do
       @map.populate_cell(Coordinate.new(4,3), @npc)
     end
 
+    let(:helper) { Rogue::VisionHelper }
+
     it "returns true if there is a clear path between two cells on the map" do
-      helper = Rogue::VisionHelper.new(@map)
-      expect(helper.clear_path_between?(source: @player, target: @npc)).to eql true
+      expect(helper.clear_path_between?(map: @map, source: @player, target: @npc)).to eql true
     end
 
     it "returns false if there is a wall blocking path between two cells on the map" do
       @map.wall_cell(Coordinate.new(2,3))
-      helper = Rogue::VisionHelper.new(@map)
-      expect(helper.clear_path_between?(source: @player, target: @npc)).to eql false
+      expect(helper.clear_path_between?(map: @map, source: @player, target: @npc)).to eql false
     end
   end
 end


### PR DESCRIPTION
fixes part 2 of #15 

Just checking if the player is within the line of view of the npc who is following. 

This is super basic and we should have a more sophisticated system for npcs where if they've seen the player once, they 'remember' where the player was last seen and go that way even if they can't see the player.

That's a whole other bit of work though, I'll create an issue for it :)