### PR TITLE
fixes: can't find executable rake for gem rake

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
+gem 'rake'
 gem 'require_all'
 gem 'rspec'
 gem 'dispel'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,6 +16,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    rake (13.0.6)
     require_all (1.3.3)
     rspec (3.2.0)
       rspec-core (~> 3.2.0)
@@ -45,5 +46,9 @@ DEPENDENCIES
   dispel
   dotenv
   pry
+  rake
   require_all
   rspec
+
+BUNDLED WITH
+   2.1.4


### PR DESCRIPTION
```
$ rake
bundler: failed to load command: rake (/Users/krisleech/.rbenv/versions/2.7.5/bin/rake)
Gem::Exception: can't find executable rake for gem rake. rake is not currently included in the bundle, perhaps you meant to add it to your Gemfile
```

Same for `bundle exec rake`.